### PR TITLE
add support for go modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ _testmain.go
 *.exe
 *.test
 *.prof
+go.sum
 
 # Logs
 *.log

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,11 @@
+module "https://github.com/grem11n/rrs-converter-go"
+
+require (
+	github.com/aws/aws-sdk-go v1.15.49
+	github.com/fatih/color v1.7.0
+	github.com/mattn/go-colorable v0.0.9 // indirect
+	github.com/mattn/go-isatty v0.0.4 // indirect
+	github.com/mattn/go-runewidth v0.0.3 // indirect
+	golang.org/x/sys v0.0.0-20181005133103-4497e2df6f9e // indirect
+	gopkg.in/cheggaaa/pb.v1 v1.0.25
+)


### PR DESCRIPTION
Info about go modules https://github.com/golang/go/wiki/Modules. 
Requirements : Go 1.11

The command `go build` will automatically download all project dependencies. When you add a new dependency with `go get {package}` go.mod will be updated to reflect changes. 

Edit:
Closes #2 